### PR TITLE
Feat/start sync

### DIFF
--- a/sequencer/api/stateapiupdater/stateapiupdater.go
+++ b/sequencer/api/stateapiupdater/stateapiupdater.go
@@ -8,6 +8,7 @@ of using this package.
 package stateapiupdater
 
 import (
+	"database/sql"
 	"fmt"
 	"sync"
 	"tokamak-sybil-resistance/common"
@@ -104,4 +105,77 @@ func NewUpdater(hdb *historydb.HistoryDB, config *historydb.NodeConfig, vars *co
 	}
 	u.SetSCVars(vars.AsPtr())
 	return &u, nil
+}
+
+// Store the State in the HistoryDB
+func (u *Updater) Store() error {
+	u.rw.RLock()
+	defer u.rw.RUnlock()
+	return common.Wrap(u.hdb.SetStateInternalAPI(&u.state))
+}
+
+// UpdateNetworkInfo update Status.Network information
+func (u *Updater) UpdateNetworkInfo(
+	lastEthBlock, lastSyncBlock common.Block,
+	lastBatchNum common.BatchNum, currentSlot int64,
+) error {
+	// Get last batch in API format
+	lastBatch, err := u.hdb.GetBatchInternalAPI(lastBatchNum)
+	if common.Unwrap(err) == sql.ErrNoRows {
+		lastBatch = nil
+	} else if err != nil {
+		return common.Wrap(err)
+	}
+	// u.rw.RLock()
+	// auctionVars := u.vars.Auction
+	// u.rw.RUnlock()
+	// Get next forgers
+	// lastClosedSlot := currentSlot + int64(auctionVars.ClosedAuctionSlots)
+	// nextForgers, err := u.hdb.GetNextForgersInternalAPI(auctionVars, &u.consts.Auction,
+	// 	lastSyncBlock, currentSlot, lastClosedSlot)
+	// if common.Unwrap(err) == sql.ErrNoRows {
+	// 	nextForgers = nil
+	// } else if err != nil {
+	// 	return common.Wrap(err)
+	// }
+
+	bucketUpdates, err := u.hdb.GetBucketUpdatesInternalAPI()
+	if err == sql.ErrNoRows {
+		bucketUpdates = nil
+	} else if err != nil {
+		return common.Wrap(err)
+	}
+
+	u.rw.Lock()
+	// Update NodeInfo struct
+	for i, bucketParams := range u.state.Rollup.Buckets {
+		for _, bucketUpdate := range bucketUpdates {
+			if bucketUpdate.NumBucket == i {
+				bucketParams.Withdrawals = bucketUpdate.Withdrawals
+				u.state.Rollup.Buckets[i] = bucketParams
+				break
+			}
+		}
+	}
+	// Update pending L1s
+	pendingL1s, err := u.hdb.GetUnforgedL1UserTxsCount()
+	if err != nil {
+		return common.Wrap(err)
+	}
+	u.state.Network.LastSyncBlock = lastSyncBlock.Num
+	u.state.Network.LastEthBlock = lastEthBlock.Num
+	u.state.Network.LastBatch = lastBatch
+	u.state.Network.CurrentSlot = currentSlot
+	// u.state.Network.NextForgers = nextForgers
+	u.state.Network.PendingL1Txs = pendingL1s
+	u.rw.Unlock()
+	return nil
+}
+
+// UpdateNetworkInfoBlock update Status.Network block related information
+func (u *Updater) UpdateNetworkInfoBlock(lastEthBlock, lastSyncBlock common.Block) {
+	u.rw.Lock()
+	u.state.Network.LastSyncBlock = lastSyncBlock.Num
+	u.state.Network.LastEthBlock = lastEthBlock.Num
+	u.rw.Unlock()
 }

--- a/sequencer/api/stateapiupdater/stateapiupdater.go
+++ b/sequencer/api/stateapiupdater/stateapiupdater.go
@@ -117,7 +117,7 @@ func (u *Updater) Store() error {
 // UpdateNetworkInfo update Status.Network information
 func (u *Updater) UpdateNetworkInfo(
 	lastEthBlock, lastSyncBlock common.Block,
-	lastBatchNum common.BatchNum, currentSlot int64,
+	lastBatchNum common.BatchNum, /*, currentSlot int64*/
 ) error {
 	// Get last batch in API format
 	lastBatch, err := u.hdb.GetBatchInternalAPI(lastBatchNum)
@@ -165,7 +165,7 @@ func (u *Updater) UpdateNetworkInfo(
 	u.state.Network.LastSyncBlock = lastSyncBlock.Num
 	u.state.Network.LastEthBlock = lastEthBlock.Num
 	u.state.Network.LastBatch = lastBatch
-	u.state.Network.CurrentSlot = currentSlot
+	// u.state.Network.CurrentSlot = currentSlot
 	// u.state.Network.NextForgers = nextForgers
 	u.state.Network.PendingL1Txs = pendingL1s
 	u.rw.Unlock()

--- a/sequencer/database/historydb/apiqueries.go
+++ b/sequencer/database/historydb/apiqueries.go
@@ -1,0 +1,42 @@
+package historydb
+
+import (
+	"tokamak-sybil-resistance/common"
+	"tokamak-sybil-resistance/database"
+
+	"github.com/russross/meddler"
+)
+
+// GetBatchInternalAPI return the batch with the given batchNum
+func (hdb *HistoryDB) GetBatchInternalAPI(batchNum common.BatchNum) (*BatchAPI, error) {
+	return hdb.getBatchAPI(hdb.dbRead, batchNum)
+}
+
+func (hdb *HistoryDB) getBatchAPI(d meddler.DB, batchNum common.BatchNum) (*BatchAPI, error) {
+	batch := &BatchAPI{}
+	if err := meddler.QueryRow(
+		d, batch,
+		`SELECT batch.item_id, batch.batch_num, batch.eth_block_num,
+		batch.forger_addr, batch.state_root, batch.num_accounts, batch.exit_root, batch.forge_l1_txs_num,
+		COALESCE(batch.eth_tx_hash, DECODE('0000000000000000000000000000000000000000000000000000000000000000', 'hex')) as eth_tx_hash,
+		block.timestamp, block.hash, COALESCE ((SELECT COUNT(*) FROM tx WHERE batch_num = batch.batch_num), 0) AS forged_txs
+	    FROM batch INNER JOIN block ON batch.eth_block_num = block.eth_block_num
+	 	WHERE batch_num = $1;`, batchNum,
+	); err != nil {
+		return nil, common.Wrap(err)
+	}
+	return batch, nil
+}
+
+// GetBucketUpdatesInternalAPI returns the latest bucket updates
+func (hdb *HistoryDB) GetBucketUpdatesInternalAPI() ([]BucketUpdateAPI, error) {
+	var bucketUpdates []*BucketUpdateAPI
+	err := meddler.QueryAll(
+		hdb.dbRead, &bucketUpdates,
+		`SELECT num_bucket, withdrawals FROM bucket_update 
+			WHERE item_id in(SELECT max(item_id) FROM bucket_update 
+			group by num_bucket) 
+			ORDER BY num_bucket ASC;`,
+	)
+	return database.SlicePtrsToSlice(bucketUpdates).([]BucketUpdateAPI), common.Wrap(err)
+}

--- a/sequencer/database/historydb/nodeinfo.go
+++ b/sequencer/database/historydb/nodeinfo.go
@@ -105,6 +105,26 @@ func (hdb *HistoryDB) SetConstants(constants *Constants) error {
 	return common.Wrap(err)
 }
 
+// SetStateInternalAPI sets the StateAPI
+func (hdb *HistoryDB) SetStateInternalAPI(stateAPI *StateAPI) error {
+	if stateAPI.Network.LastBatch != nil {
+		// stateAPI.Network.LastBatch.CollectedFeesAPI =
+		// 	apitypes.NewCollectedFeesAPI(stateAPI.Network.LastBatch.CollectedFeesDB)
+	}
+	_stateAPI := struct {
+		StateAPI *StateAPI `meddler:"state,json"`
+	}{stateAPI}
+	values, err := meddler.Default.Values(&_stateAPI, false)
+	if err != nil {
+		return common.Wrap(err)
+	}
+	_, err = hdb.dbWrite.Exec(
+		"UPDATE node_info SET state = $1 WHERE item_id = 1;",
+		values[0],
+	)
+	return common.Wrap(err)
+}
+
 // GetConstants returns the Constats
 func (hdb *HistoryDB) GetConstants() (*Constants, error) {
 	var nodeInfo NodeInfo

--- a/sequencer/database/historydb/nodeinfo.go
+++ b/sequencer/database/historydb/nodeinfo.go
@@ -107,10 +107,10 @@ func (hdb *HistoryDB) SetConstants(constants *Constants) error {
 
 // SetStateInternalAPI sets the StateAPI
 func (hdb *HistoryDB) SetStateInternalAPI(stateAPI *StateAPI) error {
-	if stateAPI.Network.LastBatch != nil {
-		// stateAPI.Network.LastBatch.CollectedFeesAPI =
-		// 	apitypes.NewCollectedFeesAPI(stateAPI.Network.LastBatch.CollectedFeesDB)
-	}
+	// if stateAPI.Network.LastBatch != nil {
+	// stateAPI.Network.LastBatch.CollectedFeesAPI =
+	// 	apitypes.NewCollectedFeesAPI(stateAPI.Network.LastBatch.CollectedFeesDB)
+	// }
 	_stateAPI := struct {
 		StateAPI *StateAPI `meddler:"state,json"`
 	}{stateAPI}

--- a/sequencer/database/historydb/nodeinfo.go
+++ b/sequencer/database/historydb/nodeinfo.go
@@ -51,11 +51,11 @@ type NetworkAPI struct {
 
 // StateAPI is an object representing the node and network state exposed via the API
 type StateAPI struct {
-	NodePublicInfo NodePublicInfo        `json:"node"`
-	Network        NetworkAPI            `json:"network"`
-	Metrics        MetricsAPI            `json:"metrics"`
-	Rollup         RollupVariablesAPI    `json:"rollup"`
-	RecommendedFee common.RecommendedFee `json:"recommendedFee"`
+	NodePublicInfo NodePublicInfo     `json:"node"`
+	Network        NetworkAPI         `json:"network"`
+	Metrics        MetricsAPI         `json:"metrics"`
+	Rollup         RollupVariablesAPI `json:"rollup"`
+	// RecommendedFee common.RecommendedFee `json:"recommendedFee"`
 }
 
 // Constants contains network constants

--- a/sequencer/database/historydb/views.go
+++ b/sequencer/database/historydb/views.go
@@ -68,6 +68,15 @@ type MetricsAPI struct {
 	EstimatedTimeToForgeL1 float64 `json:"estimatedTimeToForgeL1" meddler:"estimated_time_to_forge_l1"`
 }
 
+// BucketUpdateAPI are the bucket updates (tracking the withdrawals value changes)
+// in Rollup Smart Contract
+type BucketUpdateAPI struct {
+	EthBlockNum int64               `json:"ethereumBlockNum" meddler:"eth_block_num"`
+	NumBucket   int                 `json:"numBucket" meddler:"num_bucket"`
+	BlockStamp  int64               `json:"blockStamp" meddler:"block_stamp"`
+	Withdrawals *apitypes.BigIntStr `json:"withdrawals" meddler:"withdrawals"`
+}
+
 // BucketParamsAPI are the parameter variables of each Bucket of Rollup Smart
 // Contract
 type BucketParamsAPI struct {

--- a/sequencer/node/node.go
+++ b/sequencer/node/node.go
@@ -718,7 +718,7 @@ func (n *Node) handleNewBlock( /*ctx context.Context,*/ stats *synchronizer.Stat
 		if err := n.stateAPIUpdater.UpdateNetworkInfo(
 			stats.Eth.LastBlock, stats.Sync.LastBlock,
 			common.BatchNum(stats.Eth.LastBatchNum),
-			stats.Sync.Auction.CurrentSlot.SlotNum,
+			// stats.Sync.Auction.CurrentSlot.SlotNum,
 		); err != nil {
 			log.Errorw("ApiStateUpdater.UpdateNetworkInfo", "err", err)
 		}

--- a/sequencer/node/node.go
+++ b/sequencer/node/node.go
@@ -13,8 +13,10 @@ package node
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
+	"time"
 	"tokamak-sybil-resistance/api/stateapiupdater"
 	"tokamak-sybil-resistance/batchbuilder"
 	"tokamak-sybil-resistance/common"
@@ -563,6 +565,54 @@ func NewNode( /*mode Mode, */ cfg *config.Node, version string) (*Node, error) {
 	}, nil
 }
 
+func (n *Node) handleReorg( /*ctx context.Context,*/ stats *synchronizer.Stats,
+	vars *common.SCVariables) error {
+	// if n.mode == ModeCoordinator {
+	// 	n.coord.SendMsg(ctx, coordinator.MsgSyncReorg{
+	// 		Stats: *stats,
+	// 		Vars:  *vars.AsPtr(),
+	// 	})
+	// }
+	n.stateAPIUpdater.SetSCVars(vars.AsPtr())
+	n.stateAPIUpdater.UpdateNetworkInfoBlock(
+		stats.Eth.LastBlock, stats.Sync.LastBlock,
+	)
+	if err := n.stateAPIUpdater.Store(); err != nil {
+		return common.Wrap(err)
+	}
+	return nil
+}
+
+func (n *Node) syncLoopFn(ctx context.Context, lastBlock *common.Block) (*common.Block,
+	time.Duration, error) {
+	blockData, discarded, err := n.sync.Sync(ctx, lastBlock)
+	stats := n.sync.Stats()
+	if err != nil {
+		// case: error
+		return nil, n.cfg.Synchronizer.SyncLoopInterval.Duration, common.Wrap(err)
+	} else if discarded != nil {
+		// case: reorg
+		log.Infow("Synchronizer.Sync reorg", "discarded", *discarded)
+		vars := n.sync.SCVars()
+		if err := n.handleReorg( /*ctx,*/ stats, vars); err != nil {
+			return nil, time.Duration(0), common.Wrap(err)
+		}
+		return nil, time.Duration(0), nil
+	} else if blockData != nil {
+		// case: new block
+		vars := common.SCVariablesPtr{
+			Rollup: blockData.Rollup.Vars,
+		}
+		if err := n.handleNewBlock( /*ctx, */ stats, &vars /*, blockData.Rollup.Batches*/); err != nil {
+			return nil, time.Duration(0), common.Wrap(err)
+		}
+		return &blockData.Block, time.Duration(0), nil
+	} else {
+		// case: no block
+		return lastBlock, n.cfg.Synchronizer.SyncLoopInterval.Duration, nil
+	}
+}
+
 // StartSynchronizer starts the synchronizer
 func (n *Node) StartSynchronizer() {
 	log.Info("Starting Synchronizer...")
@@ -578,34 +628,34 @@ func (n *Node) StartSynchronizer() {
 		log.Fatalw("Node.handleNewBlock", "err", err)
 	}
 
-	// n.wg.Add(1)
-	// go func() {
-	// 	var err error
-	// 	var lastBlock *common.Block
-	// 	waitDuration := time.Duration(0)
-	// 	for {
-	// 		select {
-	// 		case <-n.ctx.Done():
-	// 			log.Info("Synchronizer done")
-	// 			n.wg.Done()
-	// 			return
-	// 		case <-time.After(waitDuration):
-	// 			if lastBlock, waitDuration, err = n.syncLoopFn(n.ctx,
-	// 				lastBlock); err != nil {
-	// 				if n.ctx.Err() != nil {
-	// 					continue
-	// 				}
-	// 				if errors.Is(err, eth.ErrBlockHashMismatchEvent) {
-	// 					log.Warnw("Synchronizer.Sync", "err", err)
-	// 				} else if errors.Is(err, synchronizer.ErrUnknownBlock) {
-	// 					log.Warnw("Synchronizer.Sync", "err", err)
-	// 				} else {
-	// 					log.Errorw("Synchronizer.Sync", "err", err)
-	// 				}
-	// 			}
-	// 		}
-	// 	}
-	// }()
+	n.wg.Add(1)
+	go func() {
+		var err error
+		var lastBlock *common.Block
+		waitDuration := time.Duration(0)
+		for {
+			select {
+			case <-n.ctx.Done():
+				log.Info("Synchronizer done")
+				n.wg.Done()
+				return
+			case <-time.After(waitDuration):
+				if lastBlock, waitDuration, err = n.syncLoopFn(n.ctx,
+					lastBlock); err != nil {
+					if n.ctx.Err() != nil {
+						continue
+					}
+					if errors.Is(err, eth.ErrBlockHashMismatchEvent) {
+						log.Warnw("Synchronizer.Sync", "err", err)
+					} else if errors.Is(err, synchronizer.ErrUnknownBlock) {
+						log.Warnw("Synchronizer.Sync", "err", err)
+					} else {
+						log.Errorw("Synchronizer.Sync", "err", err)
+					}
+				}
+			}
+		}
+	}()
 }
 
 // TODO: Update Start and Stop functionalities and Start functionality for coordinator, synchronizer


### PR DESCRIPTION
### This PR reflects the flow to start the synchronizer including:

- func `handleReorg`
- func `handleNewBlock` (only for sync)
- `stateAPIUpdater`
- historyDB queries for API updates (**TODO**: remove bucket update)