### PR TITLE
Test: Add unit test for sybil MVP

### DIFF
--- a/contracts/test/unittest/mvp.t.sol
+++ b/contracts/test/unittest/mvp.t.sol
@@ -427,4 +427,31 @@ contract MvpTest is Test, TransactionTypeHelper{
         );
     }
 
+    function testWithdrawMerkleProofTransferFails() public {
+        // Deploy RevertingReceiver contract
+
+        uint192 amount = 1 ether;
+        uint32 numExitRoot = 1;
+        uint48 idx = 0;
+
+        // Directly set exitRootsMap[numExitRoot] to a dummy value
+        bytes32 exitRootSlot = keccak256(abi.encode(numExitRoot, uint256(keccak256("exitRootsMap"))));
+        vm.store(address(sybil), exitRootSlot, bytes32(uint256(0xdeadbeef)));
+
+        // Ensure exitNullifierMap[numExitRoot][idx] is false
+        bytes32 nullifierSlot = keccak256(abi.encode(idx, keccak256(abi.encode(numExitRoot, uint256(keccak256("exitNullifierMap"))))));
+        vm.store(address(sybil), nullifierSlot, bytes32(uint256(0)));
+
+        uint256 [] memory siblings; // Empty siblings
+
+        // Expect revert due to ETH transfer failure
+        vm.expectRevert(IMVPSybil.EthTransferFailed.selector);
+        sybil.withdrawMerkleProof(
+            amount,
+            numExitRoot,
+            siblings,
+            idx
+        );
+    }
+
 }

--- a/contracts/test/unittest/mvp.t.sol
+++ b/contracts/test/unittest/mvp.t.sol
@@ -10,6 +10,7 @@ import "../../src/stub/VerifierRollupStub.sol";
 
 contract MvpTest is Test, TransactionTypeHelper{
     Sybil public sybil;
+    bytes32[] public hashes;
 
     function setUp() public {
         PoseidonUnit2 mockPoseidon2 = new PoseidonUnit2();
@@ -275,4 +276,34 @@ contract MvpTest is Test, TransactionTypeHelper{
         }(params.fromIdx, params.loadAmountF, params.amountF);
     }
 
+    // ForceExit transactions tests
+    function testForceExitTransaction() public {
+        TxParams memory params = validForceExit();
+        uint256 loadAmount = (params.loadAmountF) * 10 ** (18 - 8);
+        uint48 initialLastIdx = 256;
+
+        uint256[2] memory proofA = [uint(0),uint(0)];
+        uint256[2][2] memory proofB = [[uint(0), uint(0)], [uint(0), uint(0)]];
+        uint256[2] memory proofC = [uint(0), uint(0)];
+        uint256 input = uint(1);
+
+        vm.prank(address(this));
+        sybil.forgeBatch(
+            initialLastIdx, 
+            0xabc, 
+            0, 
+            0, 
+            0, 
+            0, 
+            proofA,
+            proofB,
+            proofC,
+            input
+        );
+
+        vm.prank(address(this));
+        sybil.exit {
+            value: loadAmount
+        }(params.fromIdx, params.loadAmountF, params.amountF);
+    }
 }

--- a/contracts/test/unittest/mvp.t.sol
+++ b/contracts/test/unittest/mvp.t.sol
@@ -306,4 +306,36 @@ contract MvpTest is Test, TransactionTypeHelper{
             value: loadAmount
         }(params.fromIdx, params.loadAmountF, params.amountF);
     }
+
+    // ForceExplode transactions tests
+    function testForceExplodeTransaction() public {
+        TxParams memory params = validForceExplode();
+        uint256 loadAmount = (params.loadAmountF) * 10 ** (18 - 8);
+        uint48 initialLastIdx = 256;
+
+        uint256[2] memory proofA = [uint(0),uint(0)];
+        uint256[2][2] memory proofB = [[uint(0), uint(0)], [uint(0), uint(0)]];
+        uint256[2] memory proofC = [uint(0), uint(0)];
+        uint256 input = uint(1);
+
+        vm.prank(address(this));
+        sybil.forgeBatch(
+            initialLastIdx, 
+            0xabc, 
+            0, 
+            0, 
+            0, 
+            0,  
+            proofA,
+            proofB,
+            proofC,
+            input
+        );
+
+        vm.prank(address(this));
+        sybil.explode {
+            value: loadAmount
+        }(params.fromIdx, params.loadAmountF, params.amountF);
+    }
+    
 }

--- a/contracts/test/unittest/mvp.t.sol
+++ b/contracts/test/unittest/mvp.t.sol
@@ -454,4 +454,123 @@ contract MvpTest is Test, TransactionTypeHelper{
         );
     }
 
+    function testWithdrawMerkleProofTransferPasses() public {
+        uint192 amount = 1 ether;
+        uint256 babyPubKey = 0x1234;
+        uint32 numExitRoot = 1;
+        uint48 idx = 2;
+        
+        // Calcuate exit root
+        bytes32 exitRoot = calculateTestExitTreeRoot();
+        
+        // forge batch with exit root
+        uint256 input = uint(1);
+        uint256[2] memory proofA = [uint(0),uint(0)];
+        uint256[2][2] memory proofB = [[uint(0), uint(0)], [uint(0), uint(0)]];
+        uint256[2] memory proofC = [uint(0), uint(0)];
+
+        vm.prank(address(this));
+        sybil.forgeBatch(
+            256, 
+            0xabc, 
+            0, 
+            0, 
+            uint(exitRoot), 
+            0, 
+            proofA,
+            proofB,
+            proofC,
+            input
+        );
+
+        /* verify
+            3rd leaf
+            0xdca3326ad7e8121bf9cf9c12333e6b2271abe823ec9edfe42f813b1e768fa57b
+
+            root
+            0xcc086fcc038189b4641db2cc4f1de3bb132aefbd65d510d817591550937818c7
+
+            index
+            2
+
+            proof
+            0x8da9e1c820f9dbd1589fd6585872bc1063588625729e7ab0797cfc63a00bd950
+            0x995788ffc103b987ad50f5e5707fd094419eb12d9552cc423bd0cd86a3861433
+        */
+        // Calculate proof (sibling)
+        uint[] memory siblings = new uint[](2);
+        siblings[0] = uint(0x8da9e1c820f9dbd1589fd6585872bc1063588625729e7ab0797cfc63a00bd950);
+        siblings[1] = uint(0x995788ffc103b987ad50f5e5707fd094419eb12d9552cc423bd0cd86a3861433);
+
+        bytes32 leaf = bytes32(0xdca3326ad7e8121bf9cf9c12333e6b2271abe823ec9edfe42f813b1e768fa57b);
+
+        // verify proof
+        bool isVerified = verify(
+            siblings,
+            exitRoot,
+            leaf,
+            idx
+        );
+
+        assert(isVerified == true);
+
+        // call withdrawMerkleProof
+        vm.expectRevert(IMVPSybil.EthTransferFailed.selector);
+        sybil.withdrawMerkleProof(
+            amount,
+            numExitRoot,
+            siblings,
+            idx
+        );   
+    }
+
+    function calculateTestExitTreeRoot() internal returns (bytes32) {
+        uint256[4] memory transactions = [uint(0), uint(1), uint(2), uint(3)];
+        uint256[4] memory keys = [uint(0), uint(1), uint(2), uint(3)];
+
+        for (uint256 i = 0; i < transactions.length; i++) {
+            uint256 hashValue = sybil._hashNode(keys[i], transactions[i]);
+            hashes.push(bytes32(hashValue));
+        }
+
+        uint256 n = transactions.length;
+        uint256 offset = 0;
+
+        while (n > 0) {
+            for (uint256 i = 0; i < n - 1; i += 2) {
+                uint256 res = sybil._hashNode(uint(hashes[offset + i]), uint(hashes[offset + i + 1]));
+                hashes.push(
+                    bytes32(res)
+                );
+            }
+            offset += n;
+            n = n / 2;
+        }
+
+        return hashes[hashes.length - 1];
+    }
+
+    function verify(
+        uint[] memory proof,
+        bytes32 root,
+        bytes32 leaf,
+        uint256 index
+    ) internal view returns (bool) {
+        uint256 hash = uint(leaf);
+
+        for (uint256 i = 0; i < proof.length; i++) {
+            uint256 proofElement = uint(proof[i]);
+
+            if (index % 2 == 0) {
+                hash = sybil._hashNode(hash, proofElement);
+            } else {
+                hash = sybil._hashNode(proofElement, hash);
+            }
+
+            index = index / 2;
+        }
+
+        return hash == uint(root);
+    }
+    
 }

--- a/contracts/test/unittest/mvp.t.sol
+++ b/contracts/test/unittest/mvp.t.sol
@@ -394,4 +394,37 @@ contract MvpTest is Test, TransactionTypeHelper{
         );
     }
 
+        // Test initializing with invalid verifier address
+    function testInitializeWithInvalidVerifierAddresses() public {
+        PoseidonUnit2 mockPoseidon2 = new PoseidonUnit2();
+        PoseidonUnit3 mockPoseidon3 = new PoseidonUnit3();
+        PoseidonUnit4 mockPoseidon4 = new PoseidonUnit4();
+        // Deploy verifier stub
+        VerifierRollupStub verifierStub = new VerifierRollupStub(); 
+        
+        address[] memory verifiers = new address[](1);
+        uint256[] memory maxTx = new uint256[](1);
+        uint256[] memory nLevels = new uint256[](1);
+
+        verifiers[0] = address(0);
+        maxTx[0] = uint(256);
+        nLevels[0] = uint(1);
+
+
+        address invalidAddress = address(0);
+
+        // Expect revert for invalid verifier address
+        Sybil newSybil = new Sybil();
+        vm.expectRevert(IMVPSybil.InvalidVerifierAddress.selector);
+        newSybil.initialize(
+            verifiers, 
+            maxTx, 
+            nLevels, 
+            120, 
+            invalidAddress, 
+            address(mockPoseidon3), 
+            address(mockPoseidon4)
+        );
+    }
+
 }

--- a/contracts/test/unittest/mvp.t.sol
+++ b/contracts/test/unittest/mvp.t.sol
@@ -337,5 +337,61 @@ contract MvpTest is Test, TransactionTypeHelper{
             value: loadAmount
         }(params.fromIdx, params.loadAmountF, params.amountF);
     }
-    
+
+    function testInitializeWithInvalidPoseidonAddresses() public {
+        PoseidonUnit2 mockPoseidon2 = new PoseidonUnit2();
+        PoseidonUnit3 mockPoseidon3 = new PoseidonUnit3();
+        PoseidonUnit4 mockPoseidon4 = new PoseidonUnit4();
+        // Deploy verifier stub
+        VerifierRollupStub verifierStub = new VerifierRollupStub(); 
+        
+        address[] memory verifiers = new address[](1);
+        uint256[] memory maxTx = new uint256[](1);
+        uint256[] memory nLevels = new uint256[](1);
+
+        verifiers[0] = address(verifierStub);
+        maxTx[0] = uint(256);
+        nLevels[0] = uint(1);
+
+
+        address invalidAddress = address(0);
+
+        // Expect revert for invalid poseidon2Elements address
+        Sybil newSybil = new Sybil();
+        vm.expectRevert();
+        newSybil.initialize(
+            verifiers, 
+            maxTx, 
+            nLevels, 
+            120, 
+            invalidAddress, 
+            address(mockPoseidon3), 
+            address(mockPoseidon4)
+        );
+
+        // Expect revert for invalid poseidon3Elements address
+        vm.expectRevert();
+        newSybil.initialize(
+            verifiers, 
+            maxTx, 
+            nLevels, 
+            120, 
+            address(mockPoseidon2), 
+            invalidAddress, 
+            address(mockPoseidon4)
+        );
+
+        // Expect revert for invalid poseidon4Elements address
+        vm.expectRevert();
+        newSybil.initialize(
+            verifiers, 
+            maxTx, 
+            nLevels, 
+            120, 
+            address(mockPoseidon2), 
+            address(mockPoseidon3),
+            invalidAddress
+        );
+    }
+
 }


### PR DESCRIPTION
This **PR** introduces six test cases.
**testForceExitTransaction()**: It tests the exit function in the contract.
**testForceExplodeTransaction()**: It tests the explode functionality of the contract.
**testInitializeWithInvalidPoseidonAddresses()**: It tests how initialise function behaves when the input Poseidon Address is invalid.
**testInitializeWithInvalidVerifierAddresses()**: It tests how initialise function behaves when the input verified Address is invalid.
**testWithdrawMerkleProofTransferFails()**: It tests the Transfer of the fund from the contract to the msg.sender fails.
**testWithdrawMerkleProofTransferPasses()**: It tests Merkle Proof of the contract.