### PR TITLE
Fix: removed handle msg from sync

### DIFF
--- a/sequencer/coordinator/coordinator.go
+++ b/sequencer/coordinator/coordinator.go
@@ -513,22 +513,6 @@ func (c *Coordinator) SendMsg(ctx context.Context, msg interface{}) {
 	}
 }
 
-func (c *Coordinator) HandleMsg(ctx context.Context, msg interface{}) error {
-	switch msg := msg.(type) {
-	case MsgSyncBlock:
-		if err := c.handleMsgSyncBlock(ctx, &msg); err != nil {
-			return fmt.Errorf("Coordinator.handleMsgSyncBlock error: %w", err)
-		}
-	// case MsgSyncReorg:
-	// 	if err := c.handleReorg(ctx, &msg); err != nil {
-	// 		return fmt.Errorf("Coordinator.handleReorg error: %w", err)
-	// 	}
-	default:
-		log.Fatalf("Coordinator Unexpected Coordinator msg of type %T: %+v", msg, msg)
-	}
-	return nil
-}
-
 // TODO: implement
 func (c *Coordinator) handleReorg(ctx context.Context, msg *MsgSyncReorg) error {
 	// c.stats = msg.Stats

--- a/sequencer/node/node.go
+++ b/sequencer/node/node.go
@@ -681,13 +681,6 @@ func (n *Node) StartSynchronizer() {
 						log.Errorw("Synchronizer.Sync", "err", err)
 					}
 				}
-			case msg := <-n.msgCh:
-				if err := n.coord.HandleMsg(n.ctx, msg); n.ctx.Err() != nil { // We will use forger here to handle the message
-					continue
-				} else if err != nil {
-					log.Fatal("Coordinator.handleMsg", "err", err)
-					continue
-				}
 			}
 		}
 	}()


### PR DESCRIPTION
- Removed handle msg from sync
- I implemented it to optimize number of go routines but now we are using co ordinator routines
- So it is not needed 