### PR TITLE
rfct/l1coordtxs

### DIFF
--- a/sequencer/coordinator/batch.go
+++ b/sequencer/coordinator/batch.go
@@ -86,8 +86,6 @@ type BatchInfo struct {
 	// L1Batch      bool
 	VerifierIdx uint8
 	L1UserTxs   []common.L1Tx
-	// L1CoordTxs            []common.L1Tx
-	L1CoordinatorTxsAuths [][]byte
 
 	ForgeBatchArgs *eth.RollupForgeBatchArgs
 	Auth           *bind.TransactOpts `json:"-"`

--- a/sequencer/coordinator/pipeline.go
+++ b/sequencer/coordinator/pipeline.go
@@ -209,7 +209,6 @@ func (p *Pipeline) forgeBatch(batchNum common.BatchNum) (
 	batchInfo.Debug.StartBlockNum = p.stats.Eth.LastBlock.Num + 1
 
 	var l1UserTxs []common.L1Tx
-	var auths [][]byte
 
 	_l1UserTxs, err := p.historyDB.GetUnforgedL1UserTxs(p.state.lastForgeL1TxsNum + 1)
 	if err != nil {
@@ -224,7 +223,7 @@ func (p *Pipeline) forgeBatch(batchNum common.BatchNum) (
 	}
 
 	// TODO: figure out what happens here and potentially remove txSelector
-	auths, l1UserTxs, err =
+	_, l1UserTxs, err =
 		p.txSelector.GetL1TxSelection(p.cfg.TxProcessorConfig, _l1UserTxs, l1UserFutureTxs)
 	if err != nil {
 		return nil, nil, common.Wrap(err)
@@ -245,7 +244,6 @@ func (p *Pipeline) forgeBatch(batchNum common.BatchNum) (
 
 	// Save metadata from TxSelector output for BatchNum
 	batchInfo.L1UserTxs = l1UserTxs
-	batchInfo.L1CoordinatorTxsAuths = auths
 
 	// Call BatchBuilder with TxSelector output
 	configBatch := &batchbuilder.ConfigBatch{
@@ -446,13 +444,12 @@ func prepareForgeBatchArgs(batchInfo *BatchInfo) *eth.RollupForgeBatchArgs {
 	proof := batchInfo.Proof
 	zki := batchInfo.ZKInputs
 	return &eth.RollupForgeBatchArgs{
-		NewLastIdx:            int64(zki.NewLastIdxRaw),
-		NewAccountRoot:        zki.NewAccountRootRaw.BigInt(),
-		NewVouchRoot:          zki.NewVouchRootRaw.BigInt(),
-		NewScoreRoot:          zki.NewScoreRootRaw.BigInt(),
-		NewExitRoot:           zki.NewExitRootRaw.BigInt(),
-		L1UserTxs:             batchInfo.L1UserTxs,
-		L1CoordinatorTxsAuths: batchInfo.L1CoordinatorTxsAuths,
+		NewLastIdx:     int64(zki.NewLastIdxRaw),
+		NewAccountRoot: zki.NewAccountRootRaw.BigInt(),
+		NewVouchRoot:   zki.NewVouchRootRaw.BigInt(),
+		NewScoreRoot:   zki.NewScoreRootRaw.BigInt(),
+		NewExitRoot:    zki.NewExitRootRaw.BigInt(),
+		L1UserTxs:      batchInfo.L1UserTxs,
 		// Circuit selector
 		VerifierIdx: batchInfo.VerifierIdx,
 		ProofA:      [2]*big.Int{proof.PiA[0], proof.PiA[1]},

--- a/sequencer/database/historydb/historydb.go
+++ b/sequencer/database/historydb/historydb.go
@@ -554,23 +554,6 @@ func (hdb *HistoryDB) GetAllL1UserTxs() ([]common.L1Tx, error) {
 	return database.SlicePtrsToSlice(txs).([]common.L1Tx), common.Wrap(err)
 }
 
-// GetAllL1CoordinatorTxs returns all L1CoordinatorTxs from the DB
-func (hdb *HistoryDB) GetAllL1CoordinatorTxs() ([]common.L1Tx, error) {
-	var txs []*common.L1Tx
-	// Since the query specifies that only coordinator txs are returned, it's safe to assume
-	// that returned txs will always have effective amounts
-	err := meddler.QueryAll(
-		hdb.dbRead, &txs,
-		`SELECT tx.id, tx.to_forge_l1_txs_num, tx.position, tx.user_origin,
-		tx.from_idx, tx.effective_from_idx, tx.from_eth_addr, tx.from_bjj, tx.to_idx,
-		tx.amount, tx.amount AS effective_amount,
-		tx.deposit_amount, tx.deposit_amount AS effective_deposit_amount,
-		tx.eth_block_num, tx.type, tx.batch_num
-		FROM tx WHERE is_l1 = TRUE AND user_origin = FALSE ORDER BY item_id;`,
-	)
-	return database.SlicePtrsToSlice(txs).([]common.L1Tx), common.Wrap(err)
-}
-
 // GetUnforgedL1UserTxs gets L1 User Txs to be forged in the L1Batch with toForgeL1TxsNum.
 func (hdb *HistoryDB) GetUnforgedL1UserTxs(toForgeL1TxsNum int64) ([]common.L1Tx, error) {
 	var txs []*common.L1Tx

--- a/sequencer/synchronizer/synchronizer_test.go
+++ b/sequencer/synchronizer/synchronizer_test.go
@@ -96,7 +96,6 @@ func checkSyncBlock(t *testing.T, s *Synchronizer, blockNum int, block,
 	require.NoError(t, err)
 	dbExits, err := s.historyDB.GetAllExits()
 	require.NoError(t, err)
-	// dbL1CoordinatorTxs := []common.L1Tx{}
 	for i, batch := range block.Rollup.Batches {
 		var dbBatch *common.Batch
 		// Find batch in DB output
@@ -352,7 +351,6 @@ func TestSyncGeneral(t *testing.T) {
 	require.Equal(t, 2, int(blocks[i].Block.Num))
 	require.Equal(t, 4, len(blocks[i].Rollup.L1UserTxs))
 	require.Equal(t, 2, len(blocks[i].Rollup.Batches))
-	// require.Equal(t, 2, len(blocks[i].Rollup.Batches[0].L1CoordinatorTxs))
 
 	// Set StateRoots for batches manually (til doesn't set it)
 	blocks[i].Rollup.Batches[0].Batch.AccountRoot =

--- a/sequencer/test/ethClient.go
+++ b/sequencer/test/ethClient.go
@@ -848,10 +848,6 @@ func (c *Client) CtlAddBlocks(blocks []common.BlockData) (err error) {
 		}
 		c.CtlSetAddr(ethCommon.HexToAddress("0xE39fEc6224708f0772D2A74fd3f9055A90E0A9f2"))
 		for _, batch := range block.Rollup.Batches {
-			// auths := make([][]byte, len(batch.L1CoordinatorTxs))
-			// for i := range auths {
-			// 	auths[i] = make([]byte, 65)
-			// }
 			if _, err := c.RollupForgeBatch(&eth.RollupForgeBatchArgs{
 				NewLastIdx: batch.Batch.LastIdx,
 
@@ -859,9 +855,6 @@ func (c *Client) CtlAddBlocks(blocks []common.BlockData) (err error) {
 				NewVouchRoot:   batch.Batch.VouchRoot,
 				NewScoreRoot:   batch.Batch.ScoreRoot,
 				NewExitRoot:    batch.Batch.ExitRoot,
-				// L1CoordinatorTxs:      batch.L1CoordinatorTxs,
-				// L1CoordinatorTxsAuths: auths,
-				// L2TxsData:             batch.L2Txs,
 				// Circuit selector
 				VerifierIdx: 0, // Intentionally empty
 				L1Batch:     batch.L1Batch,


### PR DESCRIPTION
# Refactor L1CoordTxs
- Eliminate unnecessary l1coordtxs related parts
  - From L1Tx Structure
  - From pipeline
  - From historydb
- Make sure the contract doesn't contain l1coordtxs and remove it from `rollup.go`
- Remove the l1coordtxs related parts which has been already commented out