### PR TITLE
Add minBalance and explodeAmount state variables

### DIFF
--- a/contracts/script/DeploySybil.s.sol
+++ b/contracts/script/DeploySybil.s.sol
@@ -21,6 +21,7 @@ contract FunctionScript is Script {
         address poseidon2Elements = vm.envAddress("POSEIDON2ELEMENTS");
         address poseidon3Elements = vm.envAddress("POSEIDON3ELEMENTS");
         address poseidon4Elements = vm.envAddress("POSEIDON4ELEMENTS");
+        address adminRole = msg.sender;
 
         vm.startBroadcast();
         // Deploy the Sybil contract
@@ -33,7 +34,8 @@ contract FunctionScript is Script {
             nLevel,
             poseidon2Elements,
             poseidon3Elements,
-            poseidon4Elements
+            poseidon4Elements,
+            adminRole
         );
 
         vm.stopBroadcast();

--- a/contracts/src/interfaces/IMVPSybil.sol
+++ b/contracts/src/interfaces/IMVPSybil.sol
@@ -20,7 +20,8 @@ interface IMVPSybil {
         uint256 nLevel,
         address _poseidon2Elements,
         address _poseidon3Elements,
-        address _poseidon4Elements
+        address _poseidon4Elements,
+        address _adminRole
     ) external;
 
     // L1 Transaction functions
@@ -78,5 +79,9 @@ interface IMVPSybil {
         uint256[] calldata siblings,
         uint48 idx
     ) external;
+
+    // setter functions
+    function updateExplodeAmount(uint256 _explodeAmount) external;
+    function updateMinBalance(uint256 _minBalance) external;
 
 }

--- a/contracts/src/mvp/Sybil.sol
+++ b/contracts/src/mvp/Sybil.sol
@@ -2,13 +2,12 @@
 pragma solidity 0.8.23;
 
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
-import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
 import "../interfaces/IMVPSybil.sol";
 import "../interfaces/IVerifierRollup.sol";
 import "../types/mvp/SybilHelpers.sol";
 
-contract Sybil is Initializable, OwnableUpgradeable, IMVPSybil, MVPSybilHelpers {
+contract Sybil is Initializable, AccessControlUpgradeable, IMVPSybil, MVPSybilHelpers {
 
     struct VerifierRollup {
         VerifierRollupInterface verifierInterface;
@@ -54,6 +53,8 @@ contract Sybil is Initializable, OwnableUpgradeable, IMVPSybil, MVPSybilHelpers 
         uint48 indexed idx,
         uint32 indexed numExitRoot
     );
+    event ExplodeAmountUpdated(uint256 explodeAmount);
+    event MinBalanceUpdated(uint256 minBalance);
 
     function initialize(
         address verifier,

--- a/contracts/src/mvp/Sybil.sol
+++ b/contracts/src/mvp/Sybil.sol
@@ -26,6 +26,8 @@ contract Sybil is Initializable, OwnableUpgradeable, IMVPSybil, MVPSybilHelpers 
     uint48 public lastIdx;
     uint32 public lastForgedBatch;
     uint32 public currentFillingBatch;
+    uint256 public minBalance;
+    uint256 public explodeAmount;
 
     mapping(uint32 => uint256) public accountRootMap;
     mapping(uint32 => uint256) public vouchRootMap;

--- a/contracts/test/MVP.Sybil.t.sol
+++ b/contracts/test/MVP.Sybil.t.sol
@@ -16,6 +16,7 @@ contract MvpTest is Test, TransactionTypeHelper {
         PoseidonUnit2 mockPoseidon2 = new PoseidonUnit2();
         PoseidonUnit3 mockPoseidon3 = new PoseidonUnit3();
         PoseidonUnit4 mockPoseidon4 = new PoseidonUnit4();
+        address adminRole = address(this);
         emit log_address(address(mockPoseidon2));
         emit log_address(address(mockPoseidon3));
         emit log_address(address(mockPoseidon4));
@@ -34,7 +35,8 @@ contract MvpTest is Test, TransactionTypeHelper {
             nLevels, 
             address(mockPoseidon2), 
             address(mockPoseidon3), 
-            address(mockPoseidon4)
+            address(mockPoseidon4),
+            adminRole
         );
     }
 
@@ -692,7 +694,8 @@ contract MvpTest is Test, TransactionTypeHelper {
             nLevels, 
             invalidAddress, 
             address(mockPoseidon3), 
-            address(mockPoseidon4)
+            address(mockPoseidon4),
+            address(this)
         );
 
         // Expect revert for invalid poseidon3Elements address
@@ -703,7 +706,8 @@ contract MvpTest is Test, TransactionTypeHelper {
             nLevels, 
             address(mockPoseidon2), 
             invalidAddress, 
-            address(mockPoseidon4)
+            address(mockPoseidon4),
+            address(this)
         );
 
         // Expect revert for invalid poseidon4Elements address
@@ -714,7 +718,8 @@ contract MvpTest is Test, TransactionTypeHelper {
             nLevels, 
             address(mockPoseidon2), 
             address(mockPoseidon3),
-            invalidAddress
+            invalidAddress,
+            address(this)
         );
     }
 
@@ -737,7 +742,8 @@ contract MvpTest is Test, TransactionTypeHelper {
             nLevel, 
             address(mockPoseidon2), 
             address(mockPoseidon3), 
-            address(mockPoseidon4)
+            address(mockPoseidon4),
+            address(this)
         );
     }
 
@@ -919,6 +925,40 @@ contract MvpTest is Test, TransactionTypeHelper {
         uint256 fix = m * exp;
 
         return fix;
+    }
+
+    function testUpdateExplodeAmount() public {
+        uint256 newExplodeAmount = 500;
+        vm.prank(address(this));
+        sybil.updateExplodeAmount(newExplodeAmount);
+
+        assertEq(sybil.explodeAmount(), newExplodeAmount);
+    }
+
+    function testUpdateMinBalance() public {
+        uint256 newMinBalance = 1000;
+        vm.prank(address(this));
+        sybil.updateMinBalance(newMinBalance);
+
+        assertEq(sybil.minBalance(), newMinBalance);
+    }
+
+    function testUpdateExplodeAmountByNonAdmin() public {
+        uint256 newExplodeAmount = 500;
+        address user = address(0);
+
+        vm.prank(user);
+        vm.expectRevert();
+        sybil.updateExplodeAmount(newExplodeAmount);
+    }
+
+    function testUpdateMinBalanceByNonAdmin() public {
+        uint256 newMinBalance = 1000;
+        address user = address(0);
+
+        vm.prank(user);
+        vm.expectRevert();
+        sybil.updateMinBalance(newMinBalance);
     }
 
     receive() external payable { }


### PR DESCRIPTION
This **_PR_** introduces addition of two state variables, **minBalance** and **explodeAmount**.

- Add two state variables
- Developed setter functions
- Add two events for setter functions
- Create ADMIN_ROLE for the setter functions
- Update the interface
- Update the deploy script
- Add and modified the test cases