### PR TITLE
fix/poseidon-contract

### DIFF
--- a/contracts/script/DeploySybil.s.sol
+++ b/contracts/script/DeploySybil.s.sol
@@ -20,7 +20,6 @@ contract FunctionScript is Script {
         // Specify Poseidon contract addresses
         address poseidon2Elements = vm.envAddress("POSEIDON2ELEMENTS");
         address poseidon3Elements = vm.envAddress("POSEIDON3ELEMENTS");
-        address poseidon4Elements = vm.envAddress("POSEIDON4ELEMENTS");
         address adminRole = msg.sender;
 
         vm.startBroadcast();
@@ -34,7 +33,6 @@ contract FunctionScript is Script {
             nLevel,
             poseidon2Elements,
             poseidon3Elements,
-            poseidon4Elements,
             adminRole
         );
 

--- a/contracts/src/Sybil.sol
+++ b/contracts/src/Sybil.sol
@@ -533,23 +533,6 @@ contract Sybil is Initializable, AccessControlUpgradeable, IMVPSybil, MVPSybilHe
             txnData
         );
         return uint256(sha256(inputBytes)) % _RFIELD;
-    }    
-
-    /**
-     * @dev Builds the state for the Merkle tree.
-     *
-     * @param amount The amount to be included in the state.
-     * @param user The address of the user associated with the state.
-     * 
-     * @return A uint256 array representing the state for the Merkle tree.
-    */
-    function _buildTreeState(uint192 amount, address user) internal pure returns (uint256[4] memory) {
-        uint256[4] memory state;
-        state[0] = amount;
-        state[1] = uint256(uint160(user)); // Convert address to uint256
-        state[2] = 0;
-        state[3] = 0;
-        return state;
     }
 
     /**

--- a/contracts/src/Sybil.sol
+++ b/contracts/src/Sybil.sol
@@ -65,7 +65,6 @@ contract Sybil is Initializable, AccessControlUpgradeable, IMVPSybil, MVPSybilHe
      * @param nLevel The number of levels in the verification circuit.
      * @param _poseidon2Elements The address of the Poseidon hash function elements for 2 elements.        
      * @param _poseidon3Elements The address of the Poseidon hash function elements for 3 elements.                   
-     * @param _poseidon4Elements The address of the Poseidon hash function elements for 4 elements.
      *
      * @notice The deployer of the contract will be granted the `ADMIN_ROLE`.
     */
@@ -75,7 +74,6 @@ contract Sybil is Initializable, AccessControlUpgradeable, IMVPSybil, MVPSybilHe
         uint256 nLevel,
         address _poseidon2Elements,
         address _poseidon3Elements,
-        address _poseidon4Elements,
         address _adminRole
     ) public initializer {
         lastIdx = _RESERVED_IDX;
@@ -92,8 +90,7 @@ contract Sybil is Initializable, AccessControlUpgradeable, IMVPSybil, MVPSybilHe
 
         _initializeHelpers(
             _poseidon2Elements,
-            _poseidon3Elements,
-            _poseidon4Elements
+            _poseidon3Elements
         );
     }
 

--- a/contracts/src/Sybil.sol
+++ b/contracts/src/Sybil.sol
@@ -310,8 +310,8 @@ contract Sybil is Initializable, AccessControlUpgradeable, IMVPSybil, MVPSybilHe
         uint256[] calldata siblings,
         uint48 idx
     ) external {
-        uint256[4] memory arrayState = _buildTreeState(amount, msg.sender);
-        uint256 stateHash = _hash4Elements(arrayState);
+        uint256[2] memory arrayState = _buildTreeState(amount, msg.sender);
+        uint256 stateHash = _hash2Elements(arrayState);
 
         uint256 exitRoot = exitRootMap[numExitRoot];
 

--- a/contracts/src/interfaces/IMVPSybil.sol
+++ b/contracts/src/interfaces/IMVPSybil.sol
@@ -20,7 +20,6 @@ interface IMVPSybil {
         uint256 nLevel,
         address _poseidon2Elements,
         address _poseidon3Elements,
-        address _poseidon4Elements,
         address _adminRole
     ) external;
 

--- a/contracts/src/types/SybilHelpers.sol
+++ b/contracts/src/types/SybilHelpers.sol
@@ -16,30 +16,20 @@ contract PoseidonUnit2 {
 contract PoseidonUnit3 {
     function poseidon(uint256[3] memory) public pure returns(uint256) {}
 }
-
-/**
- * @dev Interface poseidon hash function 4 elements
- */
-contract PoseidonUnit4 {
-    function poseidon(uint256[4] memory) public pure returns(uint256) {}
-}
-
 /**
  * @dev Sybil helper functions
  */
 contract MVPSybilHelpers {
     PoseidonUnit2 _insPoseidonUnit2;
     PoseidonUnit3 _insPoseidonUnit3;
-    PoseidonUnit4 _insPoseidonUnit4;
 
     /**
      * @dev Load poseidon smart contract
-     * @param _poseidon4Elements Poseidon contract address for 4 elements
+
      */
  function _initializeHelpers(
     address _poseidon2Elements,
-    address _poseidon3Elements,
-    address _poseidon4Elements
+    address _poseidon3Elements
 ) internal {
     if (_poseidon2Elements == address(0)) {
         revert InvalidPoseidonAddress("poseidon2Elements");
@@ -47,13 +37,9 @@ contract MVPSybilHelpers {
     if (_poseidon3Elements == address(0)) {
         revert InvalidPoseidonAddress("poseidon3Elements");
     }
-    if (_poseidon4Elements == address(0)) {
-        revert InvalidPoseidonAddress("poseidon4Elements");
-    }
 
     _insPoseidonUnit2 = PoseidonUnit2(_poseidon2Elements);
     _insPoseidonUnit3 = PoseidonUnit3(_poseidon3Elements);
-    _insPoseidonUnit4 = PoseidonUnit4(_poseidon4Elements);
 }
 
 
@@ -95,18 +81,6 @@ contract MVPSybilHelpers {
     view
     returns(uint256) {
         return _insPoseidonUnit3.poseidon(inputs);
-    }
-
-    /**
-     * @dev Hash poseidon for 4 elements
-     * @param inputs Poseidon input array of 4 elements
-     * @return Poseidon hash
-     */
-    function _hash4Elements(uint256[4] memory inputs)
-    internal
-    view
-    returns(uint256) {
-        return _insPoseidonUnit4.poseidon(inputs);
     }
 
     /**

--- a/contracts/src/types/SybilHelpers.sol
+++ b/contracts/src/types/SybilHelpers.sol
@@ -6,16 +6,17 @@ error InvalidPoseidonAddress(string elementType);
 /**
  * @dev Interface poseidon hash function 2 elements
  */
-contract PoseidonUnit2 {
-    function poseidon(uint256[2] memory) public pure returns(uint256) {}
+interface PoseidonUnit2 {
+    function poseidon(uint256[2] memory) external pure returns (uint256);
 }
 
 /**
  * @dev Interface poseidon hash function 3 elements
  */
-contract PoseidonUnit3 {
-    function poseidon(uint256[3] memory) public pure returns(uint256) {}
+interface PoseidonUnit3 {
+    function poseidon(uint256[3] memory) external pure returns (uint256);
 }
+
 /**
  * @dev Sybil helper functions
  */
@@ -27,47 +28,47 @@ contract MVPSybilHelpers {
      * @dev Load poseidon smart contract
 
      */
- function _initializeHelpers(
-    address _poseidon2Elements,
-    address _poseidon3Elements
-) internal {
-    if (_poseidon2Elements == address(0)) {
-        revert InvalidPoseidonAddress("poseidon2Elements");
-    }
-    if (_poseidon3Elements == address(0)) {
-        revert InvalidPoseidonAddress("poseidon3Elements");
-    }
+    function _initializeHelpers(
+        address _poseidon2Elements,
+        address _poseidon3Elements
+    ) internal {
+        if (_poseidon2Elements == address(0)) {
+            revert InvalidPoseidonAddress("poseidon2Elements");
+        }
+        if (_poseidon3Elements == address(0)) {
+            revert InvalidPoseidonAddress("poseidon3Elements");
+        }
 
-    _insPoseidonUnit2 = PoseidonUnit2(_poseidon2Elements);
-    _insPoseidonUnit3 = PoseidonUnit3(_poseidon3Elements);
-}
-
+        _insPoseidonUnit2 = PoseidonUnit2(_poseidon2Elements);
+        _insPoseidonUnit3 = PoseidonUnit3(_poseidon3Elements);
+    }
 
     // /**
     //  * @dev Builds the state for the Merkle tree.
     //  *
     //  * @param amount The amount to be included in the state.
     //  * @param user The address of the user associated with the state.
-    //  * 
+    //  *
     //  * @return A uint256 array representing the state for the Merkle tree.
     // */
-    function _buildTreeState(uint192 amount, address user) internal pure returns (uint256[2] memory) {
+    function _buildTreeState(
+        uint192 amount,
+        address user
+    ) internal pure returns (uint256[2] memory) {
         uint256[2] memory state;
         state[0] = amount;
         state[1] = uint256(uint160(user)); // Convert address to uint256
         return state;
     }
 
-
     /**
      * @dev Hash poseidon for 2 elements
      * @param inputs Poseidon input array of 2 elements
      * @return Poseidon hash
      */
-    function _hash2Elements(uint256[2] memory inputs)
-    internal
-    view
-    returns(uint256) {
+    function _hash2Elements(
+        uint256[2] memory inputs
+    ) internal view returns (uint256) {
         return _insPoseidonUnit2.poseidon(inputs);
     }
 
@@ -76,10 +77,9 @@ contract MVPSybilHelpers {
      * @param inputs Poseidon input array of 3 elements
      * @return Poseidon hash
      */
-    function _hash3Elements(uint256[3] memory inputs)
-    internal
-    view
-    returns(uint256) {
+    function _hash3Elements(
+        uint256[3] memory inputs
+    ) internal view returns (uint256) {
         return _insPoseidonUnit3.poseidon(inputs);
     }
 
@@ -89,10 +89,10 @@ contract MVPSybilHelpers {
      * @param value Input element array
      * @return Poseidon hash
      */
-    function _hashFinalNode(uint256 key, uint256 value)
-    public
-    view
-    returns(uint256) {
+    function _hashFinalNode(
+        uint256 key,
+        uint256 value
+    ) public view returns (uint256) {
         uint256[3] memory inputs;
         inputs[0] = key;
         inputs[1] = value;
@@ -113,16 +113,16 @@ contract MVPSybilHelpers {
         uint256[] calldata siblings,
         uint256 key,
         uint256 value
-    ) internal view returns(bool) {
+    ) internal view returns (bool) {
         // Step 2: Calcuate root
         uint256 nextHash = _hashFinalNode(key, value);
         uint256 siblingTmp;
         for (int256 i = int256(siblings.length) - 1; i >= 0; i--) {
             siblingTmp = siblings[uint256(i)];
             bool leftRight = (uint8(key >> uint256(i)) & 0x01) == 1;
-            nextHash = leftRight ?
-                _hashNode(siblingTmp, nextHash) :
-                _hashNode(nextHash, siblingTmp);
+            nextHash = leftRight
+                ? _hashNode(siblingTmp, nextHash)
+                : _hashNode(nextHash, siblingTmp);
         }
 
         // Step 3: Check root
@@ -135,10 +135,10 @@ contract MVPSybilHelpers {
      * @param right Input element array
      * @return Poseidon hash
      */
-    function _hashNode(uint256 left, uint256 right)
-    public
-    view
-    returns(uint256) {
+    function _hashNode(
+        uint256 left,
+        uint256 right
+    ) public view returns (uint256) {
         uint256[2] memory inputs;
         inputs[0] = left;
         inputs[1] = right;

--- a/contracts/src/types/SybilHelpers.sol
+++ b/contracts/src/types/SybilHelpers.sol
@@ -57,32 +57,21 @@ contract MVPSybilHelpers {
 }
 
 
-    /**
-     * @dev Build entry for the exit tree leaf
-     * @param nonce nonce parameter, only use 40 bits instead of 48
-     * @param balance Balance of the account
-     * @param ay Public key babyjubjub represented as point: sign + (Ay)
-     * @param ethAddress Ethereum address
-     * @return uint256 array with the state variables
-     */
-    function _buildTreeState(
-        uint48 nonce,
-        uint256 balance,
-        uint256 ay,
-        address ethAddress
-    ) internal pure returns(uint256[4] memory) {
-        uint256[4] memory stateArray;
-
-        stateArray[0] |= nonce << 32;
-        stateArray[0] |= (ay >> 255) << (32 + 40);
-        // build element 2
-        stateArray[1] = balance;
-        // build element 4
-        stateArray[2] = (ay << 1) >> 1; // last bit set to 0
-        // build element 5
-        stateArray[3] = uint256(uint160(ethAddress));
-        return stateArray;
+    // /**
+    //  * @dev Builds the state for the Merkle tree.
+    //  *
+    //  * @param amount The amount to be included in the state.
+    //  * @param user The address of the user associated with the state.
+    //  * 
+    //  * @return A uint256 array representing the state for the Merkle tree.
+    // */
+    function _buildTreeState(uint192 amount, address user) internal pure returns (uint256[2] memory) {
+        uint256[2] memory state;
+        state[0] = amount;
+        state[1] = uint256(uint160(user)); // Convert address to uint256
+        return state;
     }
+
 
     /**
      * @dev Hash poseidon for 2 elements
@@ -124,7 +113,7 @@ contract MVPSybilHelpers {
      * @dev Hash poseidon for sparse merkle tree final nodes
      * @param key Input element array
      * @param value Input element array
-     * @return Poseidon hash1
+     * @return Poseidon hash
      */
     function _hashFinalNode(uint256 key, uint256 value)
     public

--- a/contracts/test/Sybil.t.sol
+++ b/contracts/test/Sybil.t.sol
@@ -15,11 +15,9 @@ contract MvpTest is Test, TransactionTypeHelper {
     function setUp() public {
         PoseidonUnit2 mockPoseidon2 = new PoseidonUnit2();
         PoseidonUnit3 mockPoseidon3 = new PoseidonUnit3();
-        PoseidonUnit4 mockPoseidon4 = new PoseidonUnit4();
         address adminRole = address(this);
         emit log_address(address(mockPoseidon2));
         emit log_address(address(mockPoseidon3));
-        emit log_address(address(mockPoseidon4));
 
         Verifier verifierStub = new Verifier(); 
 
@@ -35,7 +33,6 @@ contract MvpTest is Test, TransactionTypeHelper {
             nLevels, 
             address(mockPoseidon2), 
             address(mockPoseidon3), 
-            address(mockPoseidon4),
             adminRole
         );
     }
@@ -675,7 +672,6 @@ contract MvpTest is Test, TransactionTypeHelper {
     function testInitializeWithInvalidPoseidonAddresses() public {
         PoseidonUnit2 mockPoseidon2 = new PoseidonUnit2();
         PoseidonUnit3 mockPoseidon3 = new PoseidonUnit3();
-        PoseidonUnit4 mockPoseidon4 = new PoseidonUnit4();
         // Deploy verifier stub
         Verifier verifierStub = new Verifier(); 
         
@@ -694,7 +690,6 @@ contract MvpTest is Test, TransactionTypeHelper {
             nLevels, 
             invalidAddress, 
             address(mockPoseidon3), 
-            address(mockPoseidon4),
             address(this)
         );
 
@@ -706,19 +701,6 @@ contract MvpTest is Test, TransactionTypeHelper {
             nLevels, 
             address(mockPoseidon2), 
             invalidAddress, 
-            address(mockPoseidon4),
-            address(this)
-        );
-
-        // Expect revert for invalid poseidon4Elements address
-        vm.expectRevert();
-        newSybil.initialize(
-            verifiers, 
-            maxTx, 
-            nLevels, 
-            address(mockPoseidon2), 
-            address(mockPoseidon3),
-            invalidAddress,
             address(this)
         );
     }
@@ -727,7 +709,6 @@ contract MvpTest is Test, TransactionTypeHelper {
     function testInitializeWithInvalidVerifierAddresses() public {
         PoseidonUnit2 mockPoseidon2 = new PoseidonUnit2();
         PoseidonUnit3 mockPoseidon3 = new PoseidonUnit3();
-        PoseidonUnit4 mockPoseidon4 = new PoseidonUnit4();
         
         address verifier = address(0);
         uint256 maxTx = uint(256);
@@ -741,8 +722,7 @@ contract MvpTest is Test, TransactionTypeHelper {
             maxTx, 
             nLevel, 
             address(mockPoseidon2), 
-            address(mockPoseidon3), 
-            address(mockPoseidon4),
+            address(mockPoseidon3),
             address(this)
         );
     }

--- a/contracts/test/Sybil.t.sol
+++ b/contracts/test/Sybil.t.sol
@@ -8,13 +8,26 @@ import "./utils/Constants.sol";
 import "./types/TransactionTypes.sol";
 import "../src/Verifier.sol";
 
+contract MockPoseidon2 is PoseidonUnit2 {
+    function poseidon(
+        uint256[2] memory input
+    ) external pure override returns (uint256) {}
+}
+
+contract MockPoseidon3 is PoseidonUnit3 {
+    function poseidon(
+        uint256[3] memory input
+    ) external pure override returns (uint256) {}
+}
+
 contract MvpTest is Test, TransactionTypeHelper {
     Sybil public sybil;
     bytes32[] public hashes;
 
     function setUp() public {
-        PoseidonUnit2 mockPoseidon2 = new PoseidonUnit2();
-        PoseidonUnit3 mockPoseidon3 = new PoseidonUnit3();
+        
+        PoseidonUnit2 mockPoseidon2 = new MockPoseidon2();
+        PoseidonUnit3 mockPoseidon3 = new MockPoseidon3();
         address adminRole = address(this);
         emit log_address(address(mockPoseidon2));
         emit log_address(address(mockPoseidon3));
@@ -670,8 +683,8 @@ contract MvpTest is Test, TransactionTypeHelper {
     }
 
     function testInitializeWithInvalidPoseidonAddresses() public {
-        PoseidonUnit2 mockPoseidon2 = new PoseidonUnit2();
-        PoseidonUnit3 mockPoseidon3 = new PoseidonUnit3();
+        PoseidonUnit2 mockPoseidon2 = new MockPoseidon2();
+        PoseidonUnit3 mockPoseidon3 = new MockPoseidon3();
         // Deploy verifier stub
         Verifier verifierStub = new Verifier(); 
         
@@ -707,8 +720,8 @@ contract MvpTest is Test, TransactionTypeHelper {
 
         // Test initializing with invalid verifier address
     function testInitializeWithInvalidVerifierAddresses() public {
-        PoseidonUnit2 mockPoseidon2 = new PoseidonUnit2();
-        PoseidonUnit3 mockPoseidon3 = new PoseidonUnit3();
+        PoseidonUnit2 mockPoseidon2 = new MockPoseidon2();
+        PoseidonUnit3 mockPoseidon3 = new MockPoseidon3();
         
         address verifier = address(0);
         uint256 maxTx = uint(256);


### PR DESCRIPTION
This _**PR**_ removes the PoseidonUnit4 contract and includes modifications to the _buildTreeState and withdrawMerkleProof functions, along with updates to the related files.