### PR TITLE
feature/endpoint to fetch account by ethaddr

### DIFF
--- a/sequencer/api/account.go
+++ b/sequencer/api/account.go
@@ -8,9 +8,9 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-func (a *API) getAccount(c *gin.Context) {
+func (a *API) getAccountByIndex(c *gin.Context) {
 	// Get Addr
-	account, err := parsers.ParseAccountFilter(c)
+	account, err := parsers.ParseAccountFilterByIndex(c)
 	if err != nil {
 		retBadReq(&apiError{
 			Err:  err,
@@ -19,7 +19,26 @@ func (a *API) getAccount(c *gin.Context) {
 		}, c)
 		return
 	}
-	apiAccount, err := a.historyDB.GetAccountAPI(*account)
+	apiAccount, err := a.historyDB.GetAccountAPIByIndex(*account)
+	if err != nil {
+		retSQLErr(err, c)
+		return
+	}
+	c.JSON(http.StatusOK, apiAccount)
+}
+
+func (a *API) getAccountByEthAddr(c *gin.Context) {
+	// Get Addr
+	account, err := parsers.ParseAccountFilterByEthAddr(c)
+	if err != nil {
+		retBadReq(&apiError{
+			Err:  err,
+			Code: ErrParamValidationFailedCode,
+			Type: ErrParamValidationFailedType,
+		}, c)
+		return
+	}
+	apiAccount, err := a.historyDB.GetAccountAPIByEthAddr(*account)
 	if err != nil {
 		retSQLErr(err, c)
 		return

--- a/sequencer/api/account_test.go
+++ b/sequencer/api/account_test.go
@@ -15,7 +15,6 @@ type testAccount struct {
 	ItemID  uint64              `json:"itemId"`
 	Idx     apitypes.TonIdx     `json:"accountIndex"`
 	EthAddr apitypes.TonEthAddr `json:"tonEthereumAddress"`
-	Nonce   common.Nonce        `json:"nonce"`
 	Balance *apitypes.BigIntStr `json:"balance"`
 }
 
@@ -26,7 +25,6 @@ func genTestAccounts(accounts []common.Account) []testAccount {
 			ItemID:  uint64(x + 1),
 			Idx:     apitypes.TonIdx(common.IdxToTon(account.Idx)),
 			EthAddr: apitypes.NewTonEthAddr(account.EthAddr),
-			Nonce:   account.Nonce,
 			Balance: apitypes.NewBigIntStr(account.Balance),
 		}
 		tAccounts = append(tAccounts, tAccount)
@@ -37,14 +35,19 @@ func genTestAccounts(accounts []common.Account) []testAccount {
 func TestGetAccounts(t *testing.T) {
 	endpoint := apiURL + "accounts"
 
-	// Test GetAccount
-	path := fmt.Sprintf("%s/%v", endpoint, tc.accounts[2].Idx)
+	// Test GetAccountByIndex
+	path := fmt.Sprintf("%s/index/%v", endpoint, tc.accounts[2].Idx)
 	account := testAccount{}
 	require.NoError(t, doGoodReq("GET", path, nil, &account))
 	assert.Equal(t, tc.accounts[2], account)
 
+	// Test GetAccountByEthAddr
+	path = fmt.Sprintf("%s/address/%v", endpoint, tc.accounts[2].EthAddr)
+	require.NoError(t, doGoodReq("GET", path, nil, &account))
+	assert.Equal(t, tc.accounts[2], account)
+
 	// 400
-	path = fmt.Sprintf("%s/ton:12345", endpoint)
+	path = fmt.Sprintf("%s/index/ton:12345", endpoint)
 	err := doBadReq("GET", path, nil, 404)
 	require.NoError(t, err)
 }

--- a/sequencer/api/api.go
+++ b/sequencer/api/api.go
@@ -71,7 +71,8 @@ func NewAPI(setup Config) (*API, error) {
 	// Add explorer endpoints
 	if setup.ExplorerEndpoints {
 		// Account
-		v1.GET("/accounts/:accountIndex", a.getAccount)
+		v1.GET("/accounts/index/:accountIndex", a.getAccountByIndex)
+		v1.GET("/accounts/address/:ethAddr", a.getAccountByEthAddr)
 		// Transaction
 		v1.GET("/transactions-history", a.getHistoryTxs)
 		v1.GET("/transactions-history/:id", a.getHistoryTx)

--- a/sequencer/api/api_test.go
+++ b/sequencer/api/api_test.go
@@ -39,7 +39,7 @@ type Pendinger interface {
 const (
 	apiPort = "4010"
 	apiIP   = "http://localhost:"
-	apiURL  = apiIP + apiPort + "/v1/"
+	apiURL  = apiIP + apiPort
 )
 
 var SetBlockchain = `

--- a/sequencer/api/api_test.go
+++ b/sequencer/api/api_test.go
@@ -232,14 +232,12 @@ func TestMain(m *testing.M) {
 			EthBlockNum: 0,
 			BatchNum:    1,
 			Idx:         *queryAccount.AccountIndex,
-			Nonce:       0,
 			Balance:     balance,
 		})
 		accUpdates = append(accUpdates, common.AccountUpdate{
 			EthBlockNum: 0,
 			BatchNum:    1,
 			Idx:         *queryAccount.AccountIndex,
-			Nonce:       accounts[i].Nonce,
 			Balance:     balance,
 		})
 	}

--- a/sequencer/api/api_test.go
+++ b/sequencer/api/api_test.go
@@ -39,7 +39,7 @@ type Pendinger interface {
 const (
 	apiPort = "4010"
 	apiIP   = "http://localhost:"
-	apiURL  = apiIP + apiPort
+	apiURL  = apiIP + apiPort + "/"
 )
 
 var SetBlockchain = `

--- a/sequencer/api/api_test.go
+++ b/sequencer/api/api_test.go
@@ -39,7 +39,7 @@ type Pendinger interface {
 const (
 	apiPort = "4010"
 	apiIP   = "http://localhost:"
-	apiURL  = apiIP + apiPort + "/"
+	apiURL  = apiIP + apiPort + "/v1/"
 )
 
 var SetBlockchain = `

--- a/sequencer/api/parsers/account.go
+++ b/sequencer/api/parsers/account.go
@@ -6,21 +6,36 @@ import (
 	"strings"
 	"tokamak-sybil-resistance/common"
 
+	ethCommon "github.com/ethereum/go-ethereum/common"
 	"github.com/gin-gonic/gin"
 )
 
 // AccountFilter for parsing /accounts/{accountIndex} request to struct
-type AccountFilter struct {
+type AccountFilterByIndex struct {
 	AccountIndex string `uri:"accountIndex" binding:"required"`
 }
 
-// ParseAccountFilter parses account filter to the account index
-func ParseAccountFilter(c *gin.Context) (*common.AccountIdx, error) {
-	var accountFilter AccountFilter
+// AccountFilterByEthAddr for parsing /accounts/{ethAddr} request to struct
+type AccountFilterByEthAddr struct {
+	EthAddr string `uri:"ethAddr" binding:"required"`
+}
+
+// ParseAccountFilterByIndex parses account filter to the account index
+func ParseAccountFilterByIndex(c *gin.Context) (*common.AccountIdx, error) {
+	var accountFilter AccountFilterByIndex
 	if err := c.ShouldBindUri(&accountFilter); err != nil {
 		return nil, common.Wrap(err)
 	}
 	return stringToAccountIdx(accountFilter.AccountIndex)
+}
+
+// ParseAccountFilterByEthAddr parses account filter to the ethAddress
+func ParseAccountFilterByEthAddr(c *gin.Context) (*ethCommon.Address, error) {
+	var accountFilter AccountFilterByEthAddr
+	if err := c.ShouldBindUri(&accountFilter); err != nil {
+		return nil, common.Wrap(err)
+	}
+	return common.TonStringToEthAddr(accountFilter.EthAddr, "ethAddr")
 }
 
 // StringToIdx converts string to account index

--- a/sequencer/api/swagger.yml
+++ b/sequencer/api/swagger.yml
@@ -38,7 +38,7 @@ info:
     url: 'https://www.gnu.org/licenses/agpl-3.0.html'
 servers:
   - description: Localhost, usefull for testing changes locally and required for unit tests
-    url: http://localhost:4010/v1
+    url: http://localhost:4010/
 tags:
   - name: Explorer
     description: Endpoints used by the nodes running in explorer mode. They are used to get information of the netwrok.

--- a/sequencer/api/swagger.yml
+++ b/sequencer/api/swagger.yml
@@ -38,7 +38,7 @@ info:
     url: 'https://www.gnu.org/licenses/agpl-3.0.html'
 servers:
   - description: Localhost, usefull for testing changes locally and required for unit tests
-    url: http://localhost:4010/
+    url: http://localhost:4010/v1/
 tags:
   - name: Explorer
     description: Endpoints used by the nodes running in explorer mode. They are used to get information of the netwrok.

--- a/sequencer/api/swagger.yml
+++ b/sequencer/api/swagger.yml
@@ -100,13 +100,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error500'
-  '/accounts/{accountIndex}':
+  '/accounts/index/{accountIndex}':
     get:
       tags:
         - Explorer
       summary: Get an account by its index.
       description: Get an account by its index.
-      operationId: getAccount
+      operationId: getAccountByIndex
       parameters:
         - name: accountIndex
           in: path
@@ -114,6 +114,45 @@ paths:
           required: true
           schema:
             $ref: '#/components/schemas/AccountIndex'
+      responses:
+        '200':
+          description: Successful operation.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Account'
+        '400':
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400'
+        '404':
+          description: Not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error404'
+        '500':
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'  
+  '/accounts/address/{ethAddr}':
+    get:
+      tags:
+        - Explorer
+      summary: Get an account by its ethAddr.
+      description: Get an account by its ethAddr.
+      operationId: getAccountByEthAddr
+      parameters:
+        - name: ethAddr
+          in: path
+          description: Identifier of an account.
+          required: true
+          schema:
+            $ref: '#/components/schemas/TonEthereumAddress'
       responses:
         '200':
           description: Successful operation.

--- a/sequencer/database/historydb/apiqueries.go
+++ b/sequencer/database/historydb/apiqueries.go
@@ -1,13 +1,11 @@
 package historydb
 
 import (
-	"errors"
 	"fmt"
 	"tokamak-sybil-resistance/common"
 	"tokamak-sybil-resistance/database"
 
 	ethCommon "github.com/ethereum/go-ethereum/common"
-	"github.com/jmoiron/sqlx"
 	"github.com/russross/meddler"
 )
 
@@ -33,7 +31,7 @@ func (hdb *HistoryDB) getBatchAPI(d meddler.DB, batchNum common.BatchNum) (*Batc
 }
 
 // GetAccountAPI returns an account by its index
-func (hdb *HistoryDB) GetAccountAPI(idx common.AccountIdx) (*AccountAPI, error) {
+func (hdb *HistoryDB) GetAccountAPIByIndex(idx common.AccountIdx) (*AccountAPI, error) {
 	cancel, err := hdb.apiConnCon.Acquire()
 	defer cancel()
 	if err != nil {
@@ -58,56 +56,28 @@ func (hdb *HistoryDB) GetAccountAPI(idx common.AccountIdx) (*AccountAPI, error) 
 	return account, nil
 }
 
-// GetAccountsAPIRequest is an API request struct for getting accounts
-type GetAccountsAPIRequest struct {
-	EthAddr *ethCommon.Address
-}
-
-// GetAccountsAPI returns a list of accounts from the DB and pagination info
-func (hdb *HistoryDB) GetAccountsAPI(
-	request GetAccountsAPIRequest,
-) ([]AccountAPI, error) {
-	if request.EthAddr == nil {
-		return nil, common.Wrap(errors.New("ethAddr is required"))
-	}
+// GetAccountAPIByIndex returns an account by its index
+func (hdb *HistoryDB) GetAccountAPIByEthAddr(ethAddr ethCommon.Address) (*AccountAPI, error) {
 	cancel, err := hdb.apiConnCon.Acquire()
 	defer cancel()
 	if err != nil {
 		return nil, common.Wrap(err)
 	}
 	defer hdb.apiConnCon.Release()
-	var query string
-	var args []interface{}
-	queryStr := `SELECT account.item_id, ton_idx(account.idx) as idx, account.batch_num, 
-	account.eth_addr, 
-	account_update.nonce, account_update.balance, COUNT(*) OVER() AS total_items
-	FROM account INNER JOIN (
-		SELECT DISTINCT idx,
-		first_value(nonce) OVER w AS nonce,
-		first_value(balance) OVER w AS balance
-		FROM account_update
-		WINDOW w as (PARTITION BY idx ORDER BY item_id DESC)
-	) AS account_update ON account_update.idx = account.idx `
-	// ethAddr filter
-	if request.EthAddr != nil {
-		queryStr += "WHERE account.eth_addr = ? "
-		args = append(args, request.EthAddr)
-	}
-	query, argsQ, err := sqlx.In(queryStr, args...)
+	account := &AccountAPI{}
+	err = meddler.QueryRow(hdb.dbRead, account, `SELECT account.item_id, ton_idx(account.idx) as idx,
+		account.batch_num, account.eth_addr, account_update.nonce, account_update.balance 
+		FROM account inner JOIN (
+			SELECT idx, nonce, balance 
+			FROM account_update
+		) AS account_update ON account_update.idx = account.idx
+		WHERE account.eth_addr = $1;`, ethAddr)
+
 	if err != nil {
 		return nil, common.Wrap(err)
 	}
-	query = hdb.dbRead.Rebind(query)
 
-	accounts := []*AccountAPI{}
-	if err := meddler.QueryAll(hdb.dbRead, &accounts, query, argsQ...); err != nil {
-		return nil, common.Wrap(err)
-	}
-	if len(accounts) == 0 {
-		return []AccountAPI{}, nil
-	}
-
-	return database.SlicePtrsToSlice(accounts).([]AccountAPI), nil
+	return account, nil
 }
 
 // GetTxAPI returns a tx from the DB given a TxID

--- a/sequencer/database/historydb/views.go
+++ b/sequencer/database/historydb/views.go
@@ -277,7 +277,6 @@ type AccountAPI struct {
 	Idx      apitypes.TonIdx     `meddler:"idx"`
 	BatchNum common.BatchNum     `meddler:"batch_num"`
 	EthAddr  apitypes.TonEthAddr `meddler:"eth_addr"`
-	Nonce    common.Nonce        `meddler:"nonce"`   // max of 40 bits used
 	Balance  *apitypes.BigIntStr `meddler:"balance"` // max of 192 bits used
 }
 
@@ -287,7 +286,6 @@ func (account AccountAPI) MarshalJSON() ([]byte, error) {
 	act := AccountAPIJSON{
 		ItemID:             account.ItemID,
 		AccountIndex:       account.Idx,
-		Nonce:              account.Nonce,
 		Balance:            account.Balance,
 		TonEthereumAddress: account.EthAddr,
 	}


### PR DESCRIPTION
# Endpoint to fetch account by ethAddr

This PR is to add endpoint to fetch account by ethAddr
- Add endpoint to fetch account by ethAddr instead of `getAccounts`
- Remove nonce field for account states
- Unit test for new endpoint with mock data
- Modify endpoint path to keep both by `accountIndex` and `ethAddr`