### PR TITLE
Implement/tx data

### DIFF
--- a/contracts/src/Sybil.sol
+++ b/contracts/src/Sybil.sol
@@ -35,6 +35,7 @@ contract Sybil is Initializable, AccessControlUpgradeable, IMVPSybil, MVPSybilHe
     mapping(uint32 => uint256) public scoreRootMap;
     mapping(uint32 => uint256) public exitRootMap;
     mapping(uint32 => bytes) public unprocessedBatchesMap;
+    mapping(uint32 => bytes32) public txsDataHashMap;
 
     // Mapping of exit nullifiers, only allowing each withdrawal to be made once
     mapping(uint32 => mapping(uint48 => bool)) public exitNullifierMap;
@@ -238,6 +239,7 @@ contract Sybil is Initializable, AccessControlUpgradeable, IMVPSybil, MVPSybilHe
      * @param newVouchRoot The new vouch root to be set for the batch.
      * @param newScoreRoot The new score root to be set for the batch.
      * @param newExitRoot The new exit root to be set for the batch.
+     * @param txsData The txsData stores the tx data that is forged
      * @param proofA The first part of the proof used for verification.
      * @param proofB The second part of the proof used for verification.
      * @param proofC The third part of the proof used for verification.
@@ -252,6 +254,7 @@ contract Sybil is Initializable, AccessControlUpgradeable, IMVPSybil, MVPSybilHe
         uint256 newVouchRoot,
         uint256 newScoreRoot,
         uint256 newExitRoot,
+        bytes calldata txsData,
         uint256[2] calldata proofA,
         uint256[2][2] calldata proofB,
         uint256[2] calldata proofC
@@ -282,6 +285,7 @@ contract Sybil is Initializable, AccessControlUpgradeable, IMVPSybil, MVPSybilHe
         vouchRootMap[lastForgedBatch] = newVouchRoot;
         scoreRootMap[lastForgedBatch] = newScoreRoot;
         exitRootMap[lastForgedBatch] = newExitRoot;
+        txsDataHashMap[lastForgedBatch] = sha256(txsData); // why use this
 
         uint16 l1UserTxsLen = _clearBatchFromQueue();
 

--- a/contracts/src/interfaces/IMVPSybil.sol
+++ b/contracts/src/interfaces/IMVPSybil.sol
@@ -39,6 +39,7 @@ interface IMVPSybil {
         uint256 newVouchRoot,
         uint256 newScoreRoot,
         uint256 newExitRoot,
+        bytes calldata txsData,
         uint256[2] calldata proofA,
         uint256[2][2] calldata proofB,
         uint256[2] calldata proofC

--- a/contracts/test/Sybil.t.sol
+++ b/contracts/test/Sybil.t.sol
@@ -55,7 +55,7 @@ contract MvpTest is Test, TransactionTypeHelper {
         uint256[2] memory proofA = [uint(0),uint(0)];
         uint256[2][2] memory proofB = [[uint(0), uint(0)], [uint(0), uint(0)]];
         uint256[2] memory proofC = [uint(0), uint(0)];
-
+        bytes memory txsData = "";
         vm.prank(address(this));
         sybil.forgeBatch(
             256, 
@@ -63,6 +63,7 @@ contract MvpTest is Test, TransactionTypeHelper {
             0, 
             0, 
             0, 
+            txsData,
             proofA,
             proofB,
             proofC
@@ -78,6 +79,7 @@ contract MvpTest is Test, TransactionTypeHelper {
         uint256[2] memory proofA = [uint(0),uint(0)];
         uint256[2][2] memory proofB = [[uint(0), uint(0)], [uint(0), uint(0)]];
         uint256[2] memory proofC = [uint(0), uint(0)];
+        bytes memory txsData = "";
 
         vm.prank(address(this));
         sybil.forgeBatch(
@@ -86,6 +88,7 @@ contract MvpTest is Test, TransactionTypeHelper {
             0, 
             0, 
             0, 
+            txsData,
             proofA,
             proofB,
             proofC
@@ -102,7 +105,8 @@ contract MvpTest is Test, TransactionTypeHelper {
         uint256[2] memory proofA = [uint(0),uint(0)];
         uint256[2][2] memory proofB = [[uint(0), uint(0)], [uint(0), uint(0)]];
         uint256[2] memory proofC = [uint(0), uint(0)];
-
+        bytes memory txsData = "";
+        
         vm.prank(address(this));
         sybil.forgeBatch(
             256, 
@@ -110,6 +114,7 @@ contract MvpTest is Test, TransactionTypeHelper {
             0, 
             0, 
             0, 
+            txsData,
             proofA,
             proofB,
             proofC
@@ -140,7 +145,8 @@ contract MvpTest is Test, TransactionTypeHelper {
         uint256[2] memory proofA = [uint(0),uint(0)];
         uint256[2][2] memory proofB = [[uint(0), uint(0)], [uint(0), uint(0)]];
         uint256[2] memory proofC = [uint(0), uint(0)];
-
+        bytes memory txsData = "";
+        
         vm.prank(address(this));
         sybil.forgeBatch(
             256, 
@@ -148,6 +154,7 @@ contract MvpTest is Test, TransactionTypeHelper {
             0, 
             0, 
             0,  
+            txsData,
             proofA,
             proofB,
             proofC
@@ -169,7 +176,8 @@ contract MvpTest is Test, TransactionTypeHelper {
         uint256[2] memory proofA = [uint(0),uint(0)];
         uint256[2][2] memory proofB = [[uint(0), uint(0)], [uint(0), uint(0)]];
         uint256[2] memory proofC = [uint(0), uint(0)];
-
+        bytes memory txsData = "";
+        
         vm.prank(address(this));
         sybil.forgeBatch(
             256, 
@@ -177,6 +185,7 @@ contract MvpTest is Test, TransactionTypeHelper {
             0, 
             0, 
             0, 
+            txsData,
             proofA,
             proofB,
             proofC
@@ -198,7 +207,8 @@ contract MvpTest is Test, TransactionTypeHelper {
         uint256[2] memory proofA = [uint(0),uint(0)];
         uint256[2][2] memory proofB = [[uint(0), uint(0)], [uint(0), uint(0)]];
         uint256[2] memory proofC = [uint(0), uint(0)];
-
+        bytes memory txsData = "";
+        
         vm.prank(address(this));
         sybil.forgeBatch(
             256, 
@@ -206,6 +216,7 @@ contract MvpTest is Test, TransactionTypeHelper {
             0, 
             0, 
             0, 
+            txsData,
             proofA,
             proofB,
             proofC
@@ -268,7 +279,8 @@ contract MvpTest is Test, TransactionTypeHelper {
         uint256[2] memory proofA = [uint(0),uint(0)];
         uint256[2][2] memory proofB = [[uint(0), uint(0)], [uint(0), uint(0)]];
         uint256[2] memory proofC = [uint(0), uint(0)];
-
+        bytes memory txsData = "";
+        
         vm.prank(address(this));
         sybil.forgeBatch(
             initialLastIdx, 
@@ -276,6 +288,7 @@ contract MvpTest is Test, TransactionTypeHelper {
             0, 
             0, 
             0, 
+            txsData,
             proofA,
             proofB,
             proofC
@@ -295,7 +308,8 @@ contract MvpTest is Test, TransactionTypeHelper {
         uint256[2] memory proofA = [uint(0),uint(0)];
         uint256[2][2] memory proofB = [[uint(0), uint(0)], [uint(0), uint(0)]];
         uint256[2] memory proofC = [uint(0), uint(0)];
-
+        bytes memory txsData = "";
+        
         vm.prank(address(this));
         sybil.forgeBatch(
             initialLastIdx, 
@@ -303,6 +317,7 @@ contract MvpTest is Test, TransactionTypeHelper {
             0, 
             0, 
             0, 
+            txsData,
             proofA,
             proofB,
             proofC
@@ -323,7 +338,8 @@ contract MvpTest is Test, TransactionTypeHelper {
         uint256[2] memory proofA = [uint(0),uint(0)];
         uint256[2][2] memory proofB = [[uint(0), uint(0)], [uint(0), uint(0)]];
         uint256[2] memory proofC = [uint(0), uint(0)];
-
+        bytes memory txsData = "";
+        
         vm.prank(address(this));
         sybil.forgeBatch(
             initialLastIdx, 
@@ -331,6 +347,7 @@ contract MvpTest is Test, TransactionTypeHelper {
             0, 
             0, 
             0, 
+            txsData,
             proofA,
             proofB,
             proofC
@@ -367,7 +384,8 @@ contract MvpTest is Test, TransactionTypeHelper {
         uint256[2] memory proofC = [uint(0), uint(0)];
 
         vm.prank(address(this));
-
+        bytes memory txsData = "";
+        
         // forging to set the lastIdx
         sybil.forgeBatch(
             initialLastIdx, 
@@ -375,6 +393,7 @@ contract MvpTest is Test, TransactionTypeHelper {
             0, 
             0, 
             0, 
+            txsData,
             proofA,
             proofB,
             proofC
@@ -391,7 +410,8 @@ contract MvpTest is Test, TransactionTypeHelper {
         uint256[2] memory proofA = [uint(0),uint(0)];
         uint256[2][2] memory proofB = [[uint(0), uint(0)], [uint(0), uint(0)]];
         uint256[2] memory proofC = [uint(0), uint(0)];
-
+        bytes memory txsData = "";
+        
         vm.prank(address(this));
         // forging to set the lastIdx
         sybil.forgeBatch(
@@ -400,6 +420,7 @@ contract MvpTest is Test, TransactionTypeHelper {
             0, 
             0, 
             0, 
+            txsData,
             proofA,
             proofB,
             proofC
@@ -418,7 +439,8 @@ contract MvpTest is Test, TransactionTypeHelper {
         uint256[2] memory proofA = [uint(0),uint(0)];
         uint256[2][2] memory proofB = [[uint(0), uint(0)], [uint(0), uint(0)]];
         uint256[2] memory proofC = [uint(0), uint(0)];
-
+        bytes memory txsData = "";
+        
         vm.prank(address(this));
         // forging to set the lastIdx
         sybil.forgeBatch(
@@ -427,6 +449,7 @@ contract MvpTest is Test, TransactionTypeHelper {
             0, 
             0, 
             0,
+            txsData,
             proofA,
             proofB,
             proofC
@@ -446,7 +469,8 @@ contract MvpTest is Test, TransactionTypeHelper {
         uint256[2] memory proofA = [uint(0),uint(0)];
         uint256[2][2] memory proofB = [[uint(0), uint(0)], [uint(0), uint(0)]];
         uint256[2] memory proofC = [uint(0), uint(0)];
-
+        bytes memory txsData = "";
+        
         vm.prank(address(this));
         // forging to set the lastIdx
         sybil.forgeBatch(
@@ -455,6 +479,7 @@ contract MvpTest is Test, TransactionTypeHelper {
             0, 
             0,
             0, 
+            txsData,
             proofA,
             proofB,
             proofC
@@ -471,7 +496,8 @@ contract MvpTest is Test, TransactionTypeHelper {
         uint256[2] memory proofA = [uint(0),uint(0)];
         uint256[2][2] memory proofB = [[uint(0), uint(0)], [uint(0), uint(0)]];
         uint256[2] memory proofC = [uint(0), uint(0)];
-
+        bytes memory txsData = "";
+        
         vm.prank(address(this));
         // forging to set the lastIdx
         sybil.forgeBatch(
@@ -480,6 +506,7 @@ contract MvpTest is Test, TransactionTypeHelper {
             0, 
             0, 
             0, 
+            txsData,
             proofA,
             proofB,
             proofC
@@ -498,7 +525,8 @@ contract MvpTest is Test, TransactionTypeHelper {
         uint256[2] memory proofA = [uint(0),uint(0)];
         uint256[2][2] memory proofB = [[uint(0), uint(0)], [uint(0), uint(0)]];
         uint256[2] memory proofC = [uint(0), uint(0)];
-
+        bytes memory txsData = "";
+        
         vm.prank(address(this));
         // forging to set the lastIdx
         sybil.forgeBatch(
@@ -507,6 +535,7 @@ contract MvpTest is Test, TransactionTypeHelper {
             0, 
             0, 
             0, 
+            txsData,
             proofA,
             proofB,
             proofC
@@ -526,7 +555,8 @@ contract MvpTest is Test, TransactionTypeHelper {
         uint256[2] memory proofA = [uint(0),uint(0)];
         uint256[2][2] memory proofB = [[uint(0), uint(0)], [uint(0), uint(0)]];
         uint256[2] memory proofC = [uint(0), uint(0)];
-
+        bytes memory txsData = "";
+        
         vm.prank(address(this));
         sybil.forgeBatch(
             initialLastIdx, 
@@ -534,6 +564,7 @@ contract MvpTest is Test, TransactionTypeHelper {
             0, 
             0, 
             0, 
+            txsData,
             proofA,
             proofB,
             proofC
@@ -550,7 +581,8 @@ contract MvpTest is Test, TransactionTypeHelper {
         uint256[2] memory proofA = [uint(0),uint(0)];
         uint256[2][2] memory proofB = [[uint(0), uint(0)], [uint(0), uint(0)]];
         uint256[2] memory proofC = [uint(0), uint(0)];
-
+        bytes memory txsData = "";
+        
         vm.prank(address(this));
         sybil.forgeBatch(
             initialLastIdx, 
@@ -558,6 +590,7 @@ contract MvpTest is Test, TransactionTypeHelper {
             0, 
             0, 
             0, 
+            txsData,
             proofA,
             proofB,
             proofC
@@ -574,7 +607,8 @@ contract MvpTest is Test, TransactionTypeHelper {
         uint256[2] memory proofA = [uint(0),uint(0)];
         uint256[2][2] memory proofB = [[uint(0), uint(0)], [uint(0), uint(0)]];
         uint256[2] memory proofC = [uint(0), uint(0)];
-
+        bytes memory txsData = "";
+        
         vm.prank(address(this));
         sybil.forgeBatch(
             initialLastIdx, 
@@ -582,6 +616,7 @@ contract MvpTest is Test, TransactionTypeHelper {
             0, 
             0, 
             0, 
+            txsData,
             proofA,
             proofB,
             proofC
@@ -602,7 +637,8 @@ contract MvpTest is Test, TransactionTypeHelper {
         uint256[2] memory proofA = [uint(0),uint(0)];
         uint256[2][2] memory proofB = [[uint(0), uint(0)], [uint(0), uint(0)]];
         uint256[2] memory proofC = [uint(0), uint(0)];
-
+        bytes memory txsData = "";
+        
         vm.prank(address(this));
         sybil.forgeBatch(
             initialLastIdx, 
@@ -610,6 +646,7 @@ contract MvpTest is Test, TransactionTypeHelper {
             0, 
             0, 
             0, 
+            txsData,
             proofA,
             proofB,
             proofC
@@ -631,7 +668,8 @@ contract MvpTest is Test, TransactionTypeHelper {
         uint256[2] memory proofA = [uint(0),uint(0)];
         uint256[2][2] memory proofB = [[uint(0), uint(0)], [uint(0), uint(0)]];
         uint256[2] memory proofC = [uint(0), uint(0)];
-
+        bytes memory txsData = "";
+        
         vm.prank(address(this));
         sybil.forgeBatch(
             initialLastIdx, 
@@ -639,6 +677,7 @@ contract MvpTest is Test, TransactionTypeHelper {
             0, 
             0, 
             0, 
+            txsData,
             proofA,
             proofB,
             proofC
@@ -660,7 +699,8 @@ contract MvpTest is Test, TransactionTypeHelper {
         uint256[2] memory proofA = [uint(0),uint(0)];
         uint256[2][2] memory proofB = [[uint(0), uint(0)], [uint(0), uint(0)]];
         uint256[2] memory proofC = [uint(0), uint(0)];
-
+        bytes memory txsData = "";
+        
         vm.prank(address(this));
         sybil.forgeBatch(
             initialLastIdx, 
@@ -668,6 +708,7 @@ contract MvpTest is Test, TransactionTypeHelper {
             0, 
             0, 
             0,
+            txsData,
             proofA,
             proofB,
             proofC
@@ -807,6 +848,7 @@ contract MvpTest is Test, TransactionTypeHelper {
         uint256[2] memory proofA = [uint(0),uint(0)];
         uint256[2][2] memory proofB = [[uint(0), uint(0)], [uint(0), uint(0)]];
         uint256[2] memory proofC = [uint(0), uint(0)];
+        bytes memory txsData = "";
         
         vm.prank(address(this));
         sybil.forgeBatch(
@@ -814,7 +856,8 @@ contract MvpTest is Test, TransactionTypeHelper {
             0xabc, 
             0, 
             0, 
-            uint(exitRoot), 
+            uint(exitRoot),
+            txsData,
             proofA,
             proofB,
             proofC
@@ -855,7 +898,7 @@ contract MvpTest is Test, TransactionTypeHelper {
             uint192(loadAmount),
             numExitRoot,
             siblings,
-            idx
+            2
         );   
         // loadAmount is transferred to this contract by Sybil.sol
         assertEq(address(this).balance, balanceBefore + loadAmount);


### PR DESCRIPTION
This PR introduces the following changes:
- Addition of txsData parameter in the forgeBatch function
- Addition of txsDataHashMap mapping to store the sha256 hash of txsData
- Updation in the test cases